### PR TITLE
Full Support for Client Connections

### DIFF
--- a/include/error-codes.hpp
+++ b/include/error-codes.hpp
@@ -42,8 +42,9 @@ constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_PARSE_FAILED = 12005;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED = 12006;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED = 12007;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED = 12008;
-constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12009;
-constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12010;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_DERIVE_FAILED = 12009;
+constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12010;
+constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12011;
 
 // Context
 constexpr int ERR_CONTEXT_BUFFER_FULL = 13001;
@@ -83,8 +84,9 @@ static std::unordered_map<int, std::string> error_messages = {
     { ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_SEND_FAILED, "SecureSocket: failed to send handshake response." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_PARSE_FAILED, "SecureSocket: failed to parse handshake response." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED, "SecureSocket: failed to derive shared secret (host)." },
-    { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED, "SecureSocket: failed to generate symmetric key." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED, "SecureSocket: failed to generate symmetric key (host)." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED, "SecureSocket: failed to finalize handshake." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_DERIVE_FAILED, "SecureSocket: failed to generate symmetric key (peer)." },
     { ERR_SECURE_SOCKET_RECV_FAILED, "SecureSocket: failed to receive incoming data" },
     { ERR_SECURE_SOCKET_SEND_FAILED, "SecureSocket: failed to send data." },
 

--- a/include/error-codes.hpp
+++ b/include/error-codes.hpp
@@ -45,8 +45,9 @@ constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED = 12006;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED = 12007;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED = 12008;
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_DERIVE_FAILED = 12009;
-constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12010;
-constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12011;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_SEND_FAILED = 12010;
+constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12011;
+constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12012;
 
 // Context
 constexpr int ERR_CONTEXT_BUFFER_FULL = 13001;
@@ -57,11 +58,11 @@ constexpr int ERR_CONTEXT_PING_FAILED = 13005;
 constexpr int ERR_CONTEXT_SEND_MESSAGE_FAILED = 13006;
 
 // Server
-constexpr int ERR_SERVER_ACCEPT_CONN_FAILED = 13003;
+constexpr int ERR_SERVER_ACCEPT_CONN_FAILED = 14001;
 
 // ThreadPool
-constexpr int ERR_THREAD_POOL_THREAD_LOOP_ERROR = 14001;
-constexpr int ERR_THREAD_POOL_DESTROY_POOL_ERROR = 14002;
+constexpr int ERR_THREAD_POOL_THREAD_LOOP_ERROR = 15001;
+constexpr int ERR_THREAD_POOL_DESTROY_POOL_ERROR = 15002;
 
 static std::unordered_map<int, std::string> error_messages = {
     // General
@@ -91,6 +92,7 @@ static std::unordered_map<int, std::string> error_messages = {
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED, "SecureSocket: failed to generate symmetric key (host)." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED, "SecureSocket: failed to finalize handshake." },
     { ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_DERIVE_FAILED, "SecureSocket: failed to generate symmetric key (peer)." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_CONFIRM_SEND_FAILED, "SecureSocket: failed to send confirmation of handshake." },
     { ERR_SECURE_SOCKET_RECV_FAILED, "SecureSocket: failed to receive incoming data" },
     { ERR_SECURE_SOCKET_SEND_FAILED, "SecureSocket: failed to send data." },
 

--- a/include/error-codes.hpp
+++ b/include/error-codes.hpp
@@ -25,13 +25,15 @@ constexpr int ERR_UNKNOWN = 10001;  // In practice, we should always endeavour t
 constexpr int ERR_SOCKET_GET_ADDR_INFO_FAILED = 11001;
 constexpr int ERR_SOCKET_BIND_SOCKET_FAILED = 11002;
 constexpr int ERR_SOCKET_LISTEN_FAILED = 11003;
-constexpr int ERR_SOCKET_MAKE_NONBLOCKING_FAILED = 11004;
-constexpr int ERR_SOCKET_ACCEPT_CONN_FAILED = 11005;
-constexpr int ERR_SOCKET_GET_HOST_FAILED = 11006;
-constexpr int ERR_SOCKET_BUFFER_FULL = 11007;
-constexpr int ERR_SOCKET_RECV_FAILED = 11008;
-constexpr int ERR_SOCKET_INVALID_SEND_ATTEMPT = 11009;
-constexpr int ERR_SOCKET_SEND_FAILED = 11010;
+constexpr int ERR_SOCKET_CONNECT_GETADDRINFO_FAILED = 11004;
+constexpr int ERR_SOCKET_CONNECT_FAILED = 1105;
+constexpr int ERR_SOCKET_MAKE_NONBLOCKING_FAILED = 11006;
+constexpr int ERR_SOCKET_ACCEPT_CONN_FAILED = 11007;
+constexpr int ERR_SOCKET_GET_HOST_FAILED = 11008;
+constexpr int ERR_SOCKET_BUFFER_FULL = 11009;
+constexpr int ERR_SOCKET_RECV_FAILED = 11010;
+constexpr int ERR_SOCKET_INVALID_SEND_ATTEMPT = 11011;
+constexpr int ERR_SOCKET_SEND_FAILED = 11012;
 
 // SecureSocket
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_INIT_FAILED = 12001;
@@ -69,6 +71,8 @@ static std::unordered_map<int, std::string> error_messages = {
     { ERR_SOCKET_GET_ADDR_INFO_FAILED, "Socket: failed to find address information." },
     { ERR_SOCKET_BIND_SOCKET_FAILED, "Socket: failed to open and bind socket." },
     { ERR_SOCKET_LISTEN_FAILED, "Socket: failed to start listening on bound socket." },
+    { ERR_SOCKET_CONNECT_GETADDRINFO_FAILED, "Socket: failed to lookup target host and port." },
+    { ERR_SOCKET_CONNECT_FAILED, "Socket: failed to connect to host after lookup." },
     { ERR_SOCKET_MAKE_NONBLOCKING_FAILED, "Socket: failed to make socket non-blocking." },
     { ERR_SOCKET_ACCEPT_CONN_FAILED, "Socket: failed to accept incoming connection." },
     { ERR_SOCKET_GET_HOST_FAILED, "Socket: failed to get host information." },

--- a/include/error-codes.hpp
+++ b/include/error-codes.hpp
@@ -35,12 +35,15 @@ constexpr int ERR_SOCKET_SEND_FAILED = 11010;
 
 // SecureSocket
 constexpr int ERR_SECURE_SOCKET_HANDSHAKE_INIT_FAILED = 12001;
-constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_PARSE_FAILED = 12002;
-constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED = 12003;
-constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED = 12004;
-constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED = 12005;
-constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12006;
-constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12007;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_PARSE_FAILED = 12002;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_DERIVE_FAILED = 12003;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_SEND_FAILED = 12004;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_PARSE_FAILED = 12005;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED = 12006;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED = 12007;
+constexpr int ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED = 12008;
+constexpr int ERR_SECURE_SOCKET_RECV_FAILED = 12009;
+constexpr int ERR_SECURE_SOCKET_SEND_FAILED = 12010;
 
 // Context
 constexpr int ERR_CONTEXT_BUFFER_FULL = 13001;
@@ -75,8 +78,11 @@ static std::unordered_map<int, std::string> error_messages = {
 
     // SecureSocket
     { ERR_SECURE_SOCKET_HANDSHAKE_INIT_FAILED, "SecureSocket: failed to initialize handshake." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_PARSE_FAILED, "SecureSocket: failed to parse handshake initialization." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_DERIVE_FAILED, "SecureSocket: failed to derive shared secret (peer)." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_ACCEPT_SEND_FAILED, "SecureSocket: failed to send handshake response." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_PARSE_FAILED, "SecureSocket: failed to parse handshake response." },
-    { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED, "SecureSocket: failed to derive shared secret." },
+    { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_DERIVE_FAILED, "SecureSocket: failed to derive shared secret (host)." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_HASH_FAILED, "SecureSocket: failed to generate symmetric key." },
     { ERR_SECURE_SOCKET_HANDSHAKE_FINAL_FAILED, "SecureSocket: failed to finalize handshake." },
     { ERR_SECURE_SOCKET_RECV_FAILED, "SecureSocket: failed to receive incoming data" },
@@ -94,8 +100,8 @@ static std::unordered_map<int, std::string> error_messages = {
     { ERR_SERVER_ACCEPT_CONN_FAILED, "Server: failed to accept incoming connection" },
 
     // ThreadPool
-    { ERR_THREAD_POOL_THREAD_LOOP_ERROR, "ThreadPool: exception occurred in task loop" },
-    { ERR_THREAD_POOL_DESTROY_POOL_ERROR, "ThreadPool: exception occurred destroying pool" },
+    { ERR_THREAD_POOL_THREAD_LOOP_ERROR, "ThreadPool: error occurred in task loop" },
+    { ERR_THREAD_POOL_DESTROY_POOL_ERROR, "ThreadPool: error occurred destroying pool" },
 };
 
 #endif

--- a/include/secure-socket.hpp
+++ b/include/secure-socket.hpp
@@ -31,6 +31,13 @@ class SecureSocket : public Socket {
         bool handshake_init();
 
         /**
+         * @brief Accepts a handshake initializtion and returns its own public key to the requestor.
+         *
+         * @return bool The success or failure of the accept attempt.
+         */
+        bool handshake_accept();
+
+        /**
          * @brief Retrieve the public key from the peer and attempt to derive a shared secret & 256-bit key.
          * 
          * @return bool The success or failure of the retrieval & derivation attempt.

--- a/include/secure-socket.hpp
+++ b/include/secure-socket.hpp
@@ -17,7 +17,8 @@ class SecureSocket : public Socket {
         bool is_secure = false;
     
     public:
-        SecureSocket();
+        SecureSocket() = default;
+        SecureSocket(Socket&& s);
         SecureSocket(SecureSocket& sock);
         SecureSocket(SecureSocket&& sock);
         SecureSocket& operator=(SecureSocket& sock);
@@ -54,9 +55,9 @@ class SecureSocket : public Socket {
         /**
          * @brief If secure, retrieves and decrypts sock data. See Socket::try_rev()
          * 
-         * @return std::pair<int, bool> The number of bytes read (-2 indicates socket is not secure, -1 indicates error) and whether the buffer has space remaining.
+         * @return std::pair<int, bool> The number of bytes read (-2 indicates socket is not secure, -1 indicates error) and the remaining buffer space.
          */
-        std::pair<int, bool> try_recv();
+        std::pair<int32_t, uint32_t> try_recv();
 
         /**
          * @brief If secure, encrypts and sends sock data. See Socket::try_send()

--- a/include/secure-socket.hpp
+++ b/include/secure-socket.hpp
@@ -45,6 +45,13 @@ class SecureSocket : public Socket {
         bool handshake_final();
 
         /**
+         * @brief Confirms that a handshake has been completed by the host and derives the shared secret + key.
+         * 
+         * @return bool The success or failure of the derivation attempt.
+         */
+        bool handshake_confirm();
+
+        /**
          * @brief If secure, retrieves and decrypts sock data. See Socket::try_rev()
          * 
          * @return std::pair<int, bool> The number of bytes read (-2 indicates socket is not secure, -1 indicates error) and whether the buffer has space remaining.

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -64,6 +64,16 @@ class Socket {
         bool try_listen(std::string port);
 
         /**
+         * @brief Attempts to connect to a listening socket via TCP with an IPv4 or IPv6 address.
+         * See man connect & man getaddrinfo.
+         * 
+         * @param host IPv4 or IPv6 host address.
+         * @param port Targeted port on host machine.
+         * @return bool The success or failure of the connection attempt.
+         */
+        bool try_connect(std::string host, std::string port);
+
+        /**
          * @brief Attempts to accept a new connection. See man accept.
          * 
          * @return bool The success or failure of the call to accept().

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -71,7 +71,7 @@ class Socket {
          * @param port Targeted port on host machine.
          * @return bool The success or failure of the connection attempt.
          */
-        bool try_connect(const std::string& host, const std::string& port);
+        bool try_connect(const std::string& host, const std::string& port, bool nonblocking = true);
 
         /**
          * @brief Attempts to accept a new connection. See man accept.
@@ -100,17 +100,21 @@ class Socket {
          * 
          * @param write_cb The callback to pass to the buffer's write function. See Buffer<T>::write()
          * @param arg The arg to pass in for access within the callback
+         * @param len If non-zero, recvfrom will block until len bytes are read.
+         * 
          * @return std::pair<int, bool> The number of bytes read (-1 indicates an error) and whether the buffer has space remaining.
          */
-        std::pair<uint32_t, bool> try_recv(uint32_t (*write_cb) (char* dest, uint32_t n, void* data) noexcept, void* arg);
+        std::pair<int32_t, uint32_t> try_recv(uint32_t (*write_cb) (char* dest, uint32_t n, void* data) noexcept, void* arg, uint32_t len = 0);
 
         /**
          * @brief Attempts to read available data from the socket stream into a buffer. Uses a default zero-copy callback to write to the buffer
          * See man recvfrom
          * 
-         * @return std::pair<int, bool> The number of bytes read (-1 indicates an error) and whether the buffer has space remaining.
+         * @param len If non-zero, recvfrom will block until len bytes are read.
+         * 
+         * @return std::pair<int, bool> The number of bytes read (-1 indicates an error) and the remaining space in the buffer.
          */
-        std::pair<uint32_t, bool> try_recv();
+        std::pair<int32_t, uint32_t> try_recv(uint32_t len = 0);
         
         /**
          * @brief Attempts to send the bytes stored in data over the network.

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -52,7 +52,7 @@ class Socket {
          * @param flags Input flags
          * @return bool The success or failure of the attempt to bind to the port. 
          */
-        bool try_listen(std::string port, int family, int socktype, int flags);
+        bool try_listen(const std::string& port, int family, int socktype, int flags);
 
         /**
          * @brief Attempts to listen for TCP IPv4 & IPv6 connections. 
@@ -61,7 +61,7 @@ class Socket {
          * @param port The port to listen to connections on
          * @return bool The success or failure of the attempt to bind to the port. 
          */
-        bool try_listen(std::string port);
+        bool try_listen(const std::string& port);
 
         /**
          * @brief Attempts to connect to a listening socket via TCP with an IPv4 or IPv6 address.
@@ -71,7 +71,7 @@ class Socket {
          * @param port Targeted port on host machine.
          * @return bool The success or failure of the connection attempt.
          */
-        bool try_connect(std::string host, std::string port);
+        bool try_connect(const std::string& host, const std::string& port);
 
         /**
          * @brief Attempts to accept a new connection. See man accept.

--- a/include/socket.hpp
+++ b/include/socket.hpp
@@ -23,6 +23,8 @@ class Socket {
     protected:
         evutil_socket_t fd;
         bool listening;
+        bool nonblocking;
+        int recv_flags;
         sockaddr_storage addr;
         socklen_t addr_len;
         CircularBuf buf;

--- a/src/circular-buffer.cpp
+++ b/src/circular-buffer.cpp
@@ -209,7 +209,6 @@ uint32_t CircularBuf::write(uint32_t cb(char* dest, uint32_t n, void* data) noex
     n = std::min(n, space());
 
     uint32_t shift;
-
     if (_w < _r || !_r) {
         shift = cb(buf + _w, n, data);
         w += shift;

--- a/src/secure-socket.cpp
+++ b/src/secure-socket.cpp
@@ -171,7 +171,12 @@ bool SecureSocket::handshake_final() {
 bool SecureSocket::handshake_confirm() {
     auto [nbytes, _] = Socket::try_recv(2); // { 1, 0 }
 
-    if (nbytes < 1) {
+    if (nbytes != 2) {
+        return false;
+    }
+
+    auto res = read_buffer(0);
+    if (res.front() != 1) {
         return false;
     }
 

--- a/src/secure-socket.cpp
+++ b/src/secure-socket.cpp
@@ -193,7 +193,7 @@ bool SecureSocket::handshake_confirm() {
     }
 
     key = secret_hash;
-    secure = true;
+    is_secure = true;
 
     return true;
 }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -262,8 +262,8 @@ std::vector<char> Socket::read_buffer(char delim) {
 
     /**
      * This might look odd: why not first search the buffer for the delimiter?
-     * O(n) complexity for each is linear, so why not spare implementing a search fn.
-     * Further, the same approach works for multi-byte delimiters.
+     * O(n) complexity for each is linear, so idea is to spare implementing a search fn
+     * with an approach that works equally well for multi-byte delimiters.
      * 
      * A better question is if we should cancel the op when delim is not found?
      * 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,9 +5,9 @@
 target_sources(server_test
     PRIVATE
         main.cpp
-        # circular-buffer.cpp
-        # socket.cpp
-        # secure-socket.cpp
+        circular-buffer.cpp
+        socket.cpp
+        secure-socket.cpp
         context.cpp
-        # server.cpp
+        server.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,9 +5,9 @@
 target_sources(server_test
     PRIVATE
         main.cpp
-        circular-buffer.cpp
-        socket.cpp
-        secure-socket.cpp
+        # circular-buffer.cpp
+        # socket.cpp
+        # secure-socket.cpp
         context.cpp
-        server.cpp
+        # server.cpp
 )

--- a/test/context.cpp
+++ b/test/context.cpp
@@ -68,11 +68,11 @@ BOOST_FIXTURE_TEST_CASE( read_sock_handles_malformed_data, ContextFixture ) {
 
     tiny_sleep();
     ctx->read_sock();
-
     ASSERT_ERR_LOGGED(ERR_CONTEXT_HANDLE_READ_FAILED);
 
     serv::proto::Error err;
     BOOST_ASSERT( err.ParseFromString(client.try_recv()) );
+
     BOOST_ASSERT( err.code() == ERR_CONTEXT_HANDLE_READ_FAILED );
 }
 
@@ -103,8 +103,6 @@ auto concat = [] (const std::string& a, const std::string& b) -> std::string {
 };
 
 BOOST_FIXTURE_TEST_CASE( read_sock_parses_header_and_request_together, ReadSockFixture ) {
-    
-
     client.try_send(concat(header_data, request_data));
     tiny_sleep();
     ctx->read_sock();

--- a/test/context.cpp
+++ b/test/context.cpp
@@ -71,7 +71,8 @@ BOOST_FIXTURE_TEST_CASE( read_sock_handles_malformed_data, ContextFixture ) {
     ASSERT_ERR_LOGGED(ERR_CONTEXT_HANDLE_READ_FAILED);
 
     serv::proto::Error err;
-    BOOST_ASSERT( err.ParseFromString(client.try_recv()) );
+    auto data = client.try_recv();
+    BOOST_ASSERT( err.ParseFromString(data) );
 
     BOOST_ASSERT( err.code() == ERR_CONTEXT_HANDLE_READ_FAILED );
 }

--- a/test/include/client.hpp
+++ b/test/include/client.hpp
@@ -103,10 +103,10 @@ class Client {
             if (!host_hs.ParseFromString(try_recv())) {
                 return false;
             }
-            
+
             dh = crpt::Exchange("ffdhe2048");
             iv = std::vector<char>(host_hs.iv().begin(), host_hs.iv().end());
-
+            
             crpt::PublicKeyDER host_pk;
             auto host_pk_str = host_hs.public_key();
             host_pk.from_vector({ host_pk_str.begin(), host_pk_str.end() });

--- a/test/include/client.hpp
+++ b/test/include/client.hpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <crypt/exchange.hpp>
 #include <crypt/crypt.hpp>
+#include "secure-socket.hpp"
 #include "host-handshake.pb.h"
 #include "peer-handshake.pb.h"
 
@@ -23,7 +24,9 @@ class Client {
         crpt::Crypt aes { "AES-256-CBC" };
         crpt::Exchange dh { "ffdhe2048" };
         bool secure = false;
-
+        serv::Socket sock;
+        serv::SecureSocket ssock;
+        
     public:
         Client(): port { "3993" }, fd { 0 } {};
         Client(std::string port): port { port }, fd { 0 } {};
@@ -50,190 +53,44 @@ class Client {
         }
 
         bool try_connect() {
-            addrinfo hints, *ai, *p;
-            memset(&hints, 0, sizeof hints);
-
-            hints.ai_family = AF_UNSPEC;
-            hints.ai_socktype = SOCK_STREAM;
-
-            int gai;
-
-            if ((gai = getaddrinfo(nullptr, port.c_str(), &hints, &ai)) != 0) {
-                std::cerr << "getaddrinfo: " << gai_strerror(gai) << std::endl;
-                exit(EXIT_FAILURE);
-            }
-
-            for (p = ai; p; p = p->ai_next) {
-                if ((fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == -1) {
-                    perror("socket");
-                    continue;
-                }
-
-                if (connect(fd, p->ai_addr, p->ai_addrlen) == -1) {
-                    perror("connect");
-                    continue;
-                }
-
-                break;
-            }
-
-            if (p == nullptr) {
-                std::cerr << "test client: failed to connect" << std::endl;
-                exit(EXIT_FAILURE);
-            }
-
-            char host[NI_MAXHOST];
-
-            if ((gai = getnameinfo(p->ai_addr, p->ai_addrlen, host, NI_MAXHOST, nullptr, 0, NI_NUMERICSERV)) != 0) {
-                std::cerr << "getnameinfo: " << gai_strerror(gai) << std::endl;
-            }
-
-            freeaddrinfo(ai);
-
-            return true;
+            return sock.try_connect("", port, false);
         }
 
-        /**
-         * @brief Convenience function to initialise a correct peer handshake response.
-         * An integration test for the sequence of calls made by this function exists in test/server.cpp.
-         */
         bool handshake_init() {
-            serv::proto::HostHandshake host_hs;
-
-            if (!host_hs.ParseFromString(try_recv())) {
-                return false;
-            }
-
-            dh = crpt::Exchange("ffdhe2048");
-            iv = std::vector<char>(host_hs.iv().begin(), host_hs.iv().end());
-            
-            crpt::PublicKeyDER host_pk;
-            auto host_pk_str = host_hs.public_key();
-            host_pk.from_vector({ host_pk_str.begin(), host_pk_str.end() });
-
-            if (!dh.derive_secret(host_pk)) {
-                return false;
-            }
-
-            serv::proto::PeerHandshake peer_hs;
-            auto peer_pk = dh.get_public_key().to_vector();
-            peer_hs.set_public_key({ peer_pk.begin(), peer_pk.end() });
-
-            if (!try_send(peer_hs.SerializeAsString())) {
-                return false;
-            }
-
-            return true;
+            secure = false;
+            ssock = serv::SecureSocket(std::move(sock));
+            return ssock.handshake_accept();
         }
 
-        /**
-         * @brief Convenience function to finalise a correct peer handshake response.
-         * An integration test for the sequence of calls made by this function exists in test/server.cpp.
-         */
         bool handshake_final() {
-            auto res = try_recv();
-            if (res.size() != 1 || res[0] != 1) {
-                return false;
+            if (ssock.handshake_confirm()) {
+                secure = true;
+                return true;
             }
-
-            auto [secret_hash, success] = crpt::Crypt::hash(dh.get_secret());
-            if (!success) {
-                return false;
-            }
-
-            key = secret_hash;
-            secure = true;
-
-            return true;
+            
+            return false;
         }
 
         bool try_close() {
-            if (!fd) return true;
-
-            if (close(fd) == -1 && errno != EBADF) {
-                perror("close");
-                return false;
-            }
-
-            fd = 0;
-            return true;
+            return sock.close_fd() || ssock.close_fd();
         }
 
-        /**
-         * @brief Appends null-terminator to end of message.
-         */
         bool try_send(const std::string req, size_t len = 0) {
-            if (!fd) {
-                return false;
-            }
-
-            if (len == 0) {
-                len = req.size();
-            }
-            
-            std::vector<char> cipher_text_cpy;
-            const char* data;
-
             if (secure) {
-                auto [cipher_text, success] = aes.encrypt(std::vector<char>(req.c_str(), req.c_str() + req.size() + 1), key, iv);
-
-                if (!success) {
-                    return false;
-                }
-
-                cipher_text_cpy = cipher_text;
-                data = cipher_text_cpy.data();
-                len = cipher_text.size();
+                return ssock.try_send(len ? req.substr(0, len) : req);
+            } else {
+                return sock.try_send(len ? req.substr(0, len) : req);
             }
-            else {
-                data = req.c_str();
-                ++len;
-            }
-
-            auto bytes_sent = 0;
-            auto total = 0;
-
-            while (total < len) {
-                if ((bytes_sent = send(fd, data + total, len - total, 0)) == -1) {
-                    perror("send");
-                    return false;
-                }
-
-                total += bytes_sent;
-            }
-
-            return true;
         }
         
-        /**
-         * @brief Assumes null-terminator present at end of messages and pops by default.
-         * 
-         * @return std::string 
-         */
         std::string try_recv() {
-            if (!fd) return "";
-
-            char buf[BUF_SIZE];
-            unsigned len;
-
-            
-            if ((len = recvfrom(fd, buf, BUF_SIZE, 0, nullptr, 0)) == -1) {
-                perror("recvfrom");
-                return "";
-            } 
-
-            if (len == 0) {
-                std::cout << "client: peer closed connection" << std::endl;
-                return "";
-            }
-
             if (secure) {
-                auto [plain_text, success] = aes.decrypt(std::vector<char>(buf, buf + len), key, iv);
-                return std::string(plain_text.begin(), plain_text.end() - 1);
+                ssock.try_recv();
+                return ssock.read_buffer();
+            } else {
+                sock.try_recv();
+                return sock.read_buffer();
             }
-
-            --len;
-            return { buf, len };
         }
 
         const evutil_socket_t get_fd() const {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -33,31 +33,6 @@ struct ServerFixture {
     }
 };
 
-BOOST_FIXTURE_TEST_CASE( handshake_integration_test, ServerFixture ) {
-    BOOST_ASSERT(client.try_connect());
-
-    serv::proto::HostHandshake host_hs;
-
-    BOOST_ASSERT(host_hs.ParseFromString(client.try_recv()));
-    auto host_pk_str = host_hs.public_key();
-
-    crpt::Exchange dh { "ffdhe2048" };
-    crpt::PublicKeyDER host_pk;
-
-    host_pk.from_vector({ host_pk_str.begin(), host_pk_str.end() });
-    serv::proto::PeerHandshake peer_hs;
-
-    auto peer_pk = dh.get_public_key().to_vector();
-    peer_hs.set_public_key({ peer_pk.begin(), peer_pk.end() });
-
-    BOOST_ASSERT(client.try_send(peer_hs.SerializeAsString()));
-
-    auto res = client.try_recv();
-    BOOST_ASSERT(res.size() == 1 && res[0] == 1);
-
-    BOOST_ASSERT(client.try_close());
-}
-
 BOOST_FIXTURE_TEST_CASE( ping_integration_test, ServerFixture ) {
     client.try_connect();
     client.handshake_init();


### PR DESCRIPTION
The Socket & SecureSocket classes now offer full support for a peer connection to the Server protocol.

- Sockets can perform the required steps to complete a secure handshake as either host or peer.
- Sockets can enable blocking I/O, ensuring that client applications which wish to manage data transfer in a dedicated blocking thread can do so.
- Blocking I/O invokes minimal syscall overhead, at zero cost to the non-blocking procedures preferred by the Server & Context.